### PR TITLE
feat: add forgejo module for homelab

### DIFF
--- a/modules/forgejo.nix
+++ b/modules/forgejo.nix
@@ -1,0 +1,48 @@
+{ inputs, ... }:
+let
+  port = 3020;
+  sshPort = 2222;
+  domain = "git.ankarhem.dev";
+in
+{
+  flake.modules.nixos.forgejo =
+    { config, ... }:
+    {
+      services.forgejo = {
+        enable = true;
+        lfs.enable = true;
+
+        settings = {
+          DEFAULT.APP_NAME = "Ankarhem Git";
+
+          server = {
+            HTTP_PORT = port;
+            HTTP_ADDR = "127.0.0.1";
+            DOMAIN = domain;
+            ROOT_URL = "https://${domain}";
+            START_SSH_SERVER = true;
+            SSH_PORT = sshPort;
+            SSH_LISTEN_PORT = sshPort;
+          };
+
+          session = {
+            COOKIE_SECURE = true;
+          };
+        };
+      };
+
+      networking.firewall.allowedTCPPorts = [ sshPort ];
+
+      services.nginx.virtualHosts."${domain}" = {
+        forceSSL = true;
+        useACMEHost = "ankarhem.dev";
+        extraConfig = ''
+          client_max_body_size 100M;
+        '';
+        locations."/" = {
+          proxyWebsockets = true;
+          proxyPass = "http://127.0.0.1:${toString port}";
+        };
+      };
+    };
+}

--- a/modules/hosts/homelab/configuration.nix
+++ b/modules/hosts/homelab/configuration.nix
@@ -29,6 +29,7 @@
         colemak
         fish
         fonts
+        forgejo
         general
         gh
         gpg


### PR DESCRIPTION
## Summary

Closes #31

Adds a Forgejo (self-hosted Git service) module and enables it on the homelab host.

### Changes

- **New file**: `modules/forgejo.nix` — Reusable `flake.modules.nixos.forgejo` module
- **Modified**: `modules/hosts/homelab/configuration.nix` — Added `forgejo` to imports

### Configuration

| Setting | Value |
|---|---|
| HTTP port | 3020 (localhost, behind nginx) |
| SSH port | 2222 (built-in SSH server) |
| Domain | `git.ankarhem.dev` |
| SSL | `*.ankarhem.dev` wildcard cert (ACME/Cloudflare) |
| Database | SQLite (default, homelab-friendly) |
| LFS | Enabled |
| `client_max_body_size` | 100M |

### Architecture decisions

- **Built-in SSH server** (`START_SSH_SERVER = true` on port 2222) keeps Forgejo self-contained without modifying the system SSH config (sshd on port 22)
- **SQLite** database is simple and sufficient for homelab scale; can migrate to PostgreSQL later
- Module follows the same pattern as `attic.nix` and `redlib.nix` — reusable `flake.modules.nixos.*` definition imported by the host

### Post-deploy steps

1. Create DNS record for `git.ankarhem.dev` pointing to the homelab IP
2. Visit `https://git.ankarhem.dev` to create the first admin account
3. Consider disabling registration afterwards (`services.forgejo.settings.service.DISABLE_REGISTRATION = true`)