### PR TITLE
ci(homelab): Add self-hosted GitHub Actions runner

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -22,7 +22,7 @@ jobs:
        contains(github.event.comment.body || '', '@omo-agent') &&
        (github.event.comment.user.login || '') != 'omo-agent' &&
        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association || ''))
-    runs-on: ubuntu-latest
+    runs-on: homelab-nix
     concurrency:
       group: opencode-${{ github.event.pull_request.number || github.event.issue.number }}
       cancel-in-progress: true

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   update:
-    runs-on: ubuntu-latest
+    runs-on: homelab-nix
     env:
       ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,5 @@
 - Use mcp-nixos when searching for nix packages or options
 - You can run `nix flake check` to check whether the flake evaluates and run its tests
 - Use `gh` cli to interact with GitHub from the command line. For example, `gh pr create` to create a pull request.
+- NEVER modify `secrets.yaml` — it is encrypted with sops and cannot be edited directly. Assume secrets exist and tell the user what secrets need to be created instead.
 

--- a/modules/hosts/homelab/_apps/default.nix
+++ b/modules/hosts/homelab/_apps/default.nix
@@ -5,6 +5,7 @@
     ./arrs/default.nix
     ./baikal.nix
     ./dokploy.nix
+    ./github-runner.nix
     ./hitster.nix
     ./immich.nix
     ./obsidian-livesync.nix

--- a/modules/hosts/homelab/_apps/github-runner.nix
+++ b/modules/hosts/homelab/_apps/github-runner.nix
@@ -1,0 +1,18 @@
+{ config, pkgs, ... }:
+{
+  sops.secrets."github/runner_token" = { };
+
+  services.github-runners.homelab = {
+    enable = true;
+    url = "https://github.com/ankarhem";
+    tokenFile = config.sops.secrets."github/runner_token".path;
+    name = "homelab";
+    extraLabels = [ "homelab-nix" ];
+    replace = true;
+    extraPackages = with pkgs; [
+      cachix
+      jq
+      nixfmt-rfc-style
+    ];
+  };
+}


### PR DESCRIPTION
## Summary

- Add `services.github-runners.homelab` NixOS module for a self-hosted GitHub Actions runner on the homelab
- Runner is registered at the user level (`https://github.com/ankarhem`) with label `homelab-nix`
- Update `update-flake.yml` and `opencode-review.yml` workflows to use `runs-on: homelab-nix`

## Post-merge steps

Add a sops secret before deploying:

```bash
sops secrets.yaml
```

```yaml
github:
    runner_token: <PAT-or-registration-token>
```

The token can be a classic PAT with `repo` scope, or a registration token from https://github.com/settings/actions/runners.