### PR TITLE
fix: correct attic cache push command in update-flake workflow

### DIFF
--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -94,7 +94,7 @@ jobs:
         if: steps.check_changes.outputs.has_changes == 'true' && env.ATTIC_TOKEN != ''
         run: |
           attic cache create main || true
-          nix path-info --all -r | attic push main
+          nix path-info --all | grep --invert '\.drv$' | attic push main --stdin
 
       - name: Create or update PR
         if: steps.check_changes.outputs.has_changes == 'true'


### PR DESCRIPTION
## Summary

Fixes the misconfigured cache push step in the update-flake workflow.

**Change**: Replaced the broken command:
```bash
nix path-info --all -r | attic push main
```
with the correct command:
```bash
nix path-info --all | grep --invert '\.drv$' | attic push main --stdin
```

**Why**:
- Removes `-r` flag to avoid pushing unnecessary runtime closure paths
- Filters out `.drv` (derivation) files which don't need to be cached
- Adds `--stdin` flag so `attic push` reads paths from stdin via the pipe

Closes #38