### PR TITLE
feat: add darwin auto-upgrade support via launchd

### DIFF
--- a/modules/auto-upgrade.nix
+++ b/modules/auto-upgrade.nix
@@ -19,24 +19,9 @@
     {
       launchd.daemons.nix-auto-upgrade = {
         enable = self ? rev;
+        command = "${pkgs.nix}/bin/nix run nix-darwin -- switch --flake github:ankarhem/nix-config -L --no-update-lock-file";
         serviceConfig = {
-          ProgramArguments = [
-            "${pkgs.nix}/bin/nix"
-            "run"
-            "nix-darwin"
-            "--"
-            "switch"
-            "--flake"
-            "github:ankarhem/nix-config"
-            "-L"
-            "--no-update-lock-file"
-          ];
-          StartCalendarInterval = [
-            {
-              Hour = 5;
-              Minute = 0;
-            }
-          ];
+          StartCalendarInterval = [{ Hour = 5; Minute = 0; }];
           StandardOutPath = "/var/log/nix-auto-upgrade.log";
           StandardErrorPath = "/var/log/nix-auto-upgrade.log";
         };

--- a/modules/auto-upgrade.nix
+++ b/modules/auto-upgrade.nix
@@ -13,4 +13,33 @@
       operation = "switch";
     };
   };
+
+  flake.modules.darwin.auto-upgrade =
+    { pkgs, ... }:
+    {
+      launchd.daemons.nix-auto-upgrade = {
+        enable = self ? rev;
+        serviceConfig = {
+          ProgramArguments = [
+            "${pkgs.nix}/bin/nix"
+            "run"
+            "nix-darwin"
+            "--"
+            "switch"
+            "--flake"
+            "github:ankarhem/nix-config"
+            "-L"
+            "--no-update-lock-file"
+          ];
+          StartCalendarInterval = [
+            {
+              Hour = 5;
+              Minute = 0;
+            }
+          ];
+          StandardOutPath = "/var/log/nix-auto-upgrade.log";
+          StandardErrorPath = "/var/log/nix-auto-upgrade.log";
+        };
+      };
+    };
 }

--- a/modules/hosts/mbp/configuration.nix
+++ b/modules/hosts/mbp/configuration.nix
@@ -12,6 +12,7 @@
           ai
           attic-client
           ankarhem
+          auto-upgrade
           chat
           colemak
           dev-tools


### PR DESCRIPTION
## Summary

- Add `flake.modules.darwin.auto-upgrade` that uses `launchd.daemons` to schedule automatic nix-darwin system upgrades, mirroring the existing NixOS `system.autoUpgrade` module
- Runs daily at 05:00 using `nix run nix-darwin -- switch --flake github:ankarhem/nix-config -L --no-update-lock-file`
- Only enabled when the flake has a git revision (`self ? rev`), matching NixOS behavior
- Added `auto-upgrade` to the mbp darwin host configuration
- Logs to `/var/log/nix-auto-upgrade.log`
- Can be triggered manually with `sudo launchctl kickstart -k system/org.nixos.nix-auto-upgrade`

Closes #40

Inspired by [booxter/nix#90](https://github.com/booxter/nix/pull/90).