### PR TITLE
fix(ci): make attic push step fail gracefully

### DIFF
--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -92,6 +92,7 @@ jobs:
 
       - name: Push to attic cache
         if: steps.check_changes.outputs.has_changes == 'true' && env.ATTIC_TOKEN != ''
+        continue-on-error: true
         run: |
           attic cache create main || true
           nix path-info --all | grep --invert '\.drv$' | attic push main --stdin


### PR DESCRIPTION
## Summary

- Add `continue-on-error: true` to the "Push to attic cache" step in `update-flake.yml`
- Ensures that if the attic push fails, the workflow continues and the flake update PR is still created/updated

Closes #43