### PR TITLE
disable: comment out workstation nixosConfiguration

### DIFF
--- a/modules/hosts/workstation/flake-parts.nix
+++ b/modules/hosts/workstation/flake-parts.nix
@@ -1,4 +1,5 @@
 { inputs, ... }:
 {
-  flake.nixosConfigurations = inputs.self.factory.nixos "x86_64-linux" "workstation";
+  # Disabled - workstation is not in use (see #42)
+  # flake.nixosConfigurations = inputs.self.factory.nixos "x86_64-linux" "workstation";
 }


### PR DESCRIPTION
## Summary

Closes #42

The workstation host is not currently in use. This PR comments out the `flake.nixosConfigurations` assignment in `modules/hosts/workstation/flake-parts.nix` to prevent it from being built.

## What changed

- **`modules/hosts/workstation/flake-parts.nix`**: Commented out `flake.nixosConfigurations = inputs.self.factory.nixos "x86_64-linux" "workstation";`

## What's preserved

- All configuration files (`configuration.nix`, `hardware-configuration.nix`) remain intact
- Re-enabling is a one-line change: uncomment the line in `flake-parts.nix`

## Impact

- `homelab` and `mbp` hosts are unaffected (independent `flake-parts.nix` files)
- No flake inputs are removed, so no lock file churn