### PR TITLE
chore: update flake.lock (2026-04-20)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -514,11 +514,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1776593771,
-        "narHash": "sha256-20InxoawdSFEEGIZlVv4py7UMVqlUOfsNKcbPFdI1Ak=",
+        "lastModified": 1776650995,
+        "narHash": "sha256-QPviU6DLdWBnRDUx3Ho25iuORhqW4ld8ml8fkiV2pZs=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "4f59334cb085c0c2e99f5cfd6915b3cb637d05f6",
+        "rev": "9c502682e2e6797773e6b4ef24fac7d09d3fd168",
         "type": "github"
       },
       "original": {
@@ -530,11 +530,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1776592962,
-        "narHash": "sha256-R2gqkCGkD0PQJJhVWKcU+5qsPBXIHT/yUTvyAOxJeGU=",
+        "lastModified": 1776661353,
+        "narHash": "sha256-Qr1MEg9aofiUHnI4Fzpefu92wglQlrL0eTUykrgtPMY=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "989d67eba0e79e1820f201f3da961ea388faa597",
+        "rev": "2171cf23bfe1d61ef24b70aa23f35e4c11d78302",
         "type": "github"
       },
       "original": {
@@ -618,11 +618,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1776591240,
-        "narHash": "sha256-HZUmD1zY5kxCDIbSpxNHkpq/Z0+ZBYGX38gf6PulwbU=",
+        "lastModified": 1776655129,
+        "narHash": "sha256-8qPKHx9VVTY2aHYkUWyRxO/l4YJurFa2U2/iYU7D9/A=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "3407d4585423a829300573743e05ffd343713e16",
+        "rev": "37b4c128405f91c43e8be96b5760140a03b71fd0",
         "type": "github"
       },
       "original": {
@@ -936,11 +936,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776592983,
-        "narHash": "sha256-3H6SsdkCGcIETSvugYXA0oWDTXGS1N4gSwnn3GTf3tM=",
+        "lastModified": 1776659439,
+        "narHash": "sha256-Zy/seVhnv3CmeoTBKxN4DpWY8hVWRXTiH+t7cAhKpN0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "78543b2992b86deef48dabfe585764e12dc9df21",
+        "rev": "e6a3a3e55b37d01b51cc0c204f0f40ea26b4193b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake.lock update.

Built and cached all NixOS configurations.