### PR TITLE
ci: add Nix to review bot environment

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -63,6 +63,25 @@ jobs:
           echo ${OMO_AGENT_PAT} | gh auth login --with-token
           gh auth status
 
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+            netrc-file = /home/runner/.config/nix/netrc
+            extra-substituters = https://attic.internetfeno.men/main
+            extra-trusted-public-keys = main:9AeGSCEdFACRMznpA8b1LZtZ6cLkpdeTQ0Hqa0RmQAA=
+
+      - name: Configure attic cache auth
+        env:
+          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
+        run: |
+          if [[ -n "$ATTIC_TOKEN" ]]; then
+            mkdir -p ~/.config/nix
+            printf 'machine attic.internetfeno.men\npassword %s\n' "$ATTIC_TOKEN" > ~/.config/nix/netrc
+            chmod 600 ~/.config/nix/netrc
+          fi
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
 


### PR DESCRIPTION
## Summary

Closes #54

Adds `cachix/install-nix-action@v31` to the `opencode-review.yml` workflow so the review bot has Nix available in its environment. This enables the bot to run `nix flake check` and other Nix commands when reviewing PRs.

### Changes
- Added `Install Nix` step using `cachix/install-nix-action@v31` (matching `update-flake.yml`)
- Added `Configure attic cache auth` step for the private substituter
- Nix config includes the same access tokens, substituters, and trusted public keys as the update workflow