### PR TITLE
fix(ci): skip review bot on automated update PRs

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -14,16 +14,15 @@ on:
 jobs:
   opencode:
     # @omo-agent mention (maintainers, exclude self) or pull_request events
-    # Skip automated PRs authored by omo-agent (e.g. flake updates)
+    # Skip automated PRs from auto/* branches (e.g. flake updates)
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
-       (github.event.pull_request.user.login || '') != 'omo-agent' &&
+       !startsWith(github.event.pull_request.head.ref, 'auto/') &&
        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association || '')) ||
       (github.event_name == 'issue_comment' &&
        contains(github.event.comment.body || '', '@omo-agent') &&
        (github.event.comment.user.login || '') != 'omo-agent' &&
-       (github.event.issue.user.login || '') != 'omo-agent' &&
        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association || ''))
     runs-on: ubuntu-latest
     concurrency:

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -14,13 +14,16 @@ on:
 jobs:
   opencode:
     # @omo-agent mention (maintainers, exclude self) or pull_request events
+    # Skip automated PRs authored by omo-agent (e.g. flake updates)
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
+       (github.event.pull_request.user.login || '') != 'omo-agent' &&
        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association || '')) ||
       (github.event_name == 'issue_comment' &&
        contains(github.event.comment.body || '', '@omo-agent') &&
        (github.event.comment.user.login || '') != 'omo-agent' &&
+       (github.event.issue.user.login || '') != 'omo-agent' &&
        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association || ''))
     runs-on: ubuntu-latest
     concurrency:


### PR DESCRIPTION
## Summary

Closes #53

Prevents the `opencode-review` workflow from triggering on automated PRs created by `omo-agent` (e.g. daily flake.lock updates from `update-flake.yml`).

## Changes

Added two exclusion checks in `.github/workflows/opencode-review.yml`:

1. **`pull_request` trigger**: Skips PRs where `github.event.pull_request.user.login == 'omo-agent'`
2. **`issue_comment` trigger**: Skips comments on PRs/issues created by `omo-agent` (via `github.event.issue.user.login`)

This ensures the review bot won't waste CI resources reviewing its own automated dependency update PRs, while still allowing manual `workflow_dispatch` invocations.

## Why author-based exclusion?

The automated PRs are authored by `omo-agent` (uses `OMO_AGENT_PAT` to push and create PRs). Checking the PR/issue author is more reliable than label-based checks because labels may not be present at the exact moment the `pull_request: opened` event fires.