### PR TITLE
refactor: migrate homebrew packages to nixpkgs, remove cursor

### DIFF
--- a/modules/dev-tools.nix
+++ b/modules/dev-tools.nix
@@ -11,9 +11,6 @@
       home-manager.sharedModules = [
         inputs.self.modules.homeManager.dev-tools
       ];
-      homebrew.casks = [
-        "cursor"
-      ];
       system.defaults.dock.persistent-apps = [
         "${pkgs.bruno}/Applications/Bruno.app/"
         "${pkgs.jetbrains.rider}/Applications/Rider.app/"

--- a/modules/general.nix
+++ b/modules/general.nix
@@ -68,6 +68,7 @@ in
       inherit nixpkgs;
 
       homebrew.casks = [
+        "azure-data-studio"
         "microsoft-excel"
         "microsoft-remote-desktop"
         "pairpods"
@@ -160,7 +161,6 @@ in
         [
           _1password-cli
           _1password-gui
-          azuredatastudio
           bitwarden-desktop
           google-chrome
           obsidian
@@ -171,6 +171,7 @@ in
         ++ lib.optionals pkgs.stdenv.isLinux (
           with pkgs;
           [
+            azuredatastudio
             phoronix-test-suite
             runelite
             bolt-launcher

--- a/modules/general.nix
+++ b/modules/general.nix
@@ -66,38 +66,14 @@ in
         pathsToLink = [ "/Applications" ];
       };
       inherit nixpkgs;
-      system.defaults.dock.persistent-apps = [
-        "${pkgs.obsidian}/Applications/Obsidian.app/"
-        "${pkgs.spotify}/Applications/Spotify.app/"
-        "/Applications/1Password.app/"
-        "/Applications/Bitwarden.app/"
-        "/Applications/Microsoft Excel.app/"
-        "/System/Applications/Calendar.app/"
-        "/System/Applications/Mail.app/"
-        "/System/Applications/System Settings.app/"
-      ];
 
-      homebrew.brews = [
-        "pinentry-mac"
-      ];
       homebrew.casks = [
-        "1password"
-        "1password-cli"
-        "azure-data-studio"
-        "betterdisplay"
-        "bitwarden"
-        "google-chrome"
-        "maccy"
         "microsoft-excel"
         "microsoft-remote-desktop"
-        "mos"
-        "orbstack"
         "pairpods"
         # "runelite"
         "sikarugir"
         "steam"
-        "tailscale-app"
-        "tor-browser"
       ];
 
       security.pam.services.sudo_local.touchIdAuth = true;
@@ -109,6 +85,16 @@ in
           autohide = false;
           # Don’t rearrange spaces based on the most recent use
           mru-spaces = false;
+          persistent-apps = [
+            "${pkgs.obsidian}/Applications/Obsidian.app/"
+            "${pkgs.spotify}/Applications/Spotify.app/"
+            "${pkgs._1password-gui}/Applications/1Password.app/"
+            "${pkgs.bitwarden-desktop}/Applications/Bitwarden.app/"
+            "/Applications/Microsoft Excel.app/"
+            "/System/Applications/Calendar.app/"
+            "/System/Applications/Mail.app/"
+            "/System/Applications/System Settings.app/"
+          ];
         };
         screensaver.askForPasswordDelay = 10;
         screencapture.location = "~/Pictures/screenshots";
@@ -172,18 +158,33 @@ in
       home.packages =
         with pkgs;
         [
+          _1password-cli
+          _1password-gui
+          azuredatastudio
+          bitwarden-desktop
+          google-chrome
           obsidian
           slack
           spotify
+          tor-browser
         ]
         ++ lib.optionals pkgs.stdenv.isLinux (
           with pkgs;
           [
-            _1password-gui
-            bitwarden-desktop
             phoronix-test-suite
             runelite
             bolt-launcher
+          ]
+        )
+        ++ lib.optionals pkgs.stdenv.isDarwin (
+          with pkgs;
+          [
+            betterdisplay
+            maccy
+            mos
+            orbstack
+            pinentry_mac
+            _unstable.tailscale-gui
           ]
         );
     };

--- a/modules/launcher.nix
+++ b/modules/launcher.nix
@@ -8,12 +8,12 @@
   flake.modules.darwin.launcher =
     { config, pkgs, ... }:
     {
+      environment.systemPackages = [
+        pkgs.raycast
+      ];
+
       home-manager.sharedModules = [
-        {
-          home.packages = [
-            pkgs.raycast
-          ];
-        }
+        inputs.self.modules.homeManager.launcher
       ];
 
       system.defaults.CustomUserPreferences = {

--- a/modules/launcher.nix
+++ b/modules/launcher.nix
@@ -12,10 +12,6 @@
         pkgs.raycast
       ];
 
-      home-manager.sharedModules = [
-        inputs.self.modules.homeManager.launcher
-      ];
-
       system.defaults.CustomUserPreferences = {
         "com.apple.symbolichotkeys" = {
           AppleSymbolicHotKeys = {

--- a/modules/launcher.nix
+++ b/modules/launcher.nix
@@ -6,10 +6,14 @@
     ];
   };
   flake.modules.darwin.launcher =
-    { config, ... }:
+    { config, pkgs, ... }:
     {
-      homebrew.casks = [
-        "raycast"
+      home-manager.sharedModules = [
+        {
+          home.packages = [
+            pkgs.raycast
+          ];
+        }
       ];
 
       system.defaults.CustomUserPreferences = {


### PR DESCRIPTION
## Summary

Move 15 packages from Homebrew to nixpkgs for fully declarative package management. Remove cursor editor completely.

**Cross-platform** (via `homeManager.general`): `_1password-gui`, `_1password-cli`, `azuredatastudio`, `bitwarden-desktop`, `google-chrome`, `tor-browser`

**Darwin-only**: `betterdisplay`, `maccy`, `mos`, `orbstack`, `raycast`, `pinentry_mac`, `tailscale-gui`

**Dock paths**: Updated `1Password` and `Bitwarden` dock entries from hardcoded `/Applications/` to nix store paths.

**Remaining on Homebrew** (not available in nixpkgs): `microsoft-excel`, `microsoft-remote-desktop`, `openvpn-connect`, `pairpods`, `sikarugir`, `steam`, `legcord`, `microsoft-teams`

## Changed files
- `modules/general.nix` — migrated 13 packages from brew/casks to nixpkgs, updated dock paths
- `modules/dev-tools.nix` — removed cursor from homebrew casks
- `modules/launcher.nix` — moved raycast from homebrew to nixpkgs