### PR TITLE
feat(zed): add color-highlight extension

### DIFF
--- a/modules/zed.nix
+++ b/modules/zed.nix
@@ -12,6 +12,7 @@
           "cargo-tom"
           "catppuccin-icons"
           "codebook"
+          "color-highlight"
           "csharp"
           "discord-presence"
           "dockerfile"


### PR DESCRIPTION
Closes #64

Adds the [color-highlight](https://github.com/huacnlee/color-lsp/tree/main/zed-color-highlight) Zed extension to the extensions list.

This extension highlights colors in the editor based on color-lsp, supporting HTML, CSS, JS/TS, YAML, TOML, and many other file types.