### PR TITLE
feat(homelab): Add hermes-agent service

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -390,6 +390,27 @@
     "flake-parts_4": {
       "inputs": {
         "nixpkgs-lib": [
+          "hermes-agent",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1772408722,
+        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_5": {
+      "inputs": {
+        "nixpkgs-lib": [
           "llm-agents",
           "nixpkgs"
         ]
@@ -408,7 +429,7 @@
         "type": "github"
       }
     },
-    "flake-parts_5": {
+    "flake-parts_6": {
       "inputs": {
         "nixpkgs-lib": [
           "nur",
@@ -429,7 +450,7 @@
         "type": "github"
       }
     },
-    "flake-parts_6": {
+    "flake-parts_7": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib_4"
       },
@@ -660,6 +681,31 @@
         "type": "github"
       }
     },
+    "hermes-agent": {
+      "inputs": {
+        "flake-parts": "flake-parts_4",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "npm-lockfile-fix": "npm-lockfile-fix",
+        "pyproject-build-systems": "pyproject-build-systems",
+        "pyproject-nix": "pyproject-nix_2",
+        "uv2nix": "uv2nix_2"
+      },
+      "locked": {
+        "lastModified": 1780382495,
+        "narHash": "sha256-h5JS3fo25+/1bz8ifohrI6Yp3+8rIdtLF8IfJdAHOl0=",
+        "owner": "NousResearch",
+        "repo": "hermes-agent",
+        "rev": "3c1d066a8a82b9f78cdf093a7103278c9a783de8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NousResearch",
+        "repo": "hermes-agent",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -784,7 +830,7 @@
       "inputs": {
         "blueprint": "blueprint_2",
         "bun2nix": "bun2nix",
-        "flake-parts": "flake-parts_4",
+        "flake-parts": "flake-parts_5",
         "nixpkgs": "nixpkgs_6",
         "systems": "systems_2",
         "treefmt-nix": "treefmt-nix_2"
@@ -1163,9 +1209,30 @@
         "type": "github"
       }
     },
+    "npm-lockfile-fix": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775903712,
+        "narHash": "sha256-2GV79U6iVH4gKAPWYrxUReB0S41ty/Y3dBLquU8AlaA=",
+        "owner": "jeslie0",
+        "repo": "npm-lockfile-fix",
+        "rev": "c6093acb0c0548e0f9b8b3d82918823721930fe8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "jeslie0",
+        "repo": "npm-lockfile-fix",
+        "type": "github"
+      }
+    },
     "nur": {
       "inputs": {
-        "flake-parts": "flake-parts_5",
+        "flake-parts": "flake-parts_6",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -1219,6 +1286,94 @@
         "type": "github"
       }
     },
+    "pyproject-build-systems": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "nixpkgs"
+        ],
+        "pyproject-nix": "pyproject-nix",
+        "uv2nix": "uv2nix"
+      },
+      "locked": {
+        "lastModified": 1772555609,
+        "narHash": "sha256-3BA3HnUvJSbHJAlJj6XSy0Jmu7RyP2gyB/0fL7XuEDo=",
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "rev": "c37f66a953535c394244888598947679af231863",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "type": "github"
+      }
+    },
+    "pyproject-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "pyproject-build-systems",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1769936401,
+        "narHash": "sha256-kwCOegKLZJM9v/e/7cqwg1p/YjjTAukKPqmxKnAZRgA=",
+        "owner": "nix-community",
+        "repo": "pyproject.nix",
+        "rev": "b0d513eeeebed6d45b4f2e874f9afba2021f7812",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
+    "pyproject-nix_2": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1772865871,
+        "narHash": "sha256-/ZTSg97aouL0SlPHaokA4r3iuH9QzHVuWPACD2CUCFY=",
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "rev": "e537db02e72d553cea470976b9733581bcf5b3ed",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
+    "pyproject-nix_3": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "uv2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1771518446,
+        "narHash": "sha256-nFJSfD89vWTu92KyuJWDoTQJuoDuddkJV3TlOl1cOic=",
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "rev": "eb204c6b3335698dec6c7fc1da0ebc3c6df05937",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "agent-browser": "agent-browser",
@@ -1227,6 +1382,7 @@
         "flake-parts": "flake-parts_2",
         "git-hooks": "git-hooks",
         "graylog-cli": "graylog-cli",
+        "hermes-agent": "hermes-agent",
         "home-manager": "home-manager",
         "homebrew-bundle": "homebrew-bundle",
         "homebrew-cask": "homebrew-cask",
@@ -1585,7 +1741,7 @@
     "truesight": {
       "inputs": {
         "fenix": "fenix_3",
-        "flake-parts": "flake-parts_6",
+        "flake-parts": "flake-parts_7",
         "git-hooks": "git-hooks_4",
         "nixpkgs": [
           "nixpkgs"
@@ -1603,6 +1759,55 @@
       "original": {
         "owner": "ankarhem",
         "repo": "truesight",
+        "type": "github"
+      }
+    },
+    "uv2nix": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "pyproject-build-systems",
+          "nixpkgs"
+        ],
+        "pyproject-nix": [
+          "hermes-agent",
+          "pyproject-build-systems",
+          "pyproject-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1770770348,
+        "narHash": "sha256-A2GzkmzdYvdgmMEu5yxW+xhossP+txrYb7RuzRaqhlg=",
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "rev": "5d1b2cb4fe3158043fbafbbe2e46238abbc954b0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "type": "github"
+      }
+    },
+    "uv2nix_2": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "nixpkgs"
+        ],
+        "pyproject-nix": "pyproject-nix_3"
+      },
+      "locked": {
+        "lastModified": 1773039484,
+        "narHash": "sha256-+boo33KYkJDw9KItpeEXXv8+65f7hHv/earxpcyzQ0I=",
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "rev": "b68be7cfeacbed9a3fa38a2b5adc0cfb81d9bb1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -10,6 +10,8 @@
     flake-parts.url = "github:hercules-ci/flake-parts";
     git-hooks.url = "github:cachix/git-hooks.nix";
     graylog-cli.url = "github:norcetech/graylog-cli";
+    hermes-agent.inputs.nixpkgs.follows = "nixpkgs";
+    hermes-agent.url = "github:NousResearch/hermes-agent";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
     home-manager.url = "github:nix-community/home-manager/release-26.05";
     homebrew-bundle.flake = false;

--- a/modules/hosts/homelab/_apps/default.nix
+++ b/modules/hosts/homelab/_apps/default.nix
@@ -5,6 +5,7 @@
     ./arrs/default.nix
     ./baikal.nix
     ./dokploy.nix
+    ./hermes.nix
     ./hitster.nix
     ./immich.nix
     ./obsidian-livesync.nix

--- a/modules/hosts/homelab/_apps/hermes.nix
+++ b/modules/hosts/homelab/_apps/hermes.nix
@@ -1,0 +1,65 @@
+{
+  config,
+  inputs,
+  ...
+}:
+{
+  imports = [
+    inputs.hermes-agent.nixosModules.default
+  ];
+
+  # Reuse the existing z.ai / GLM key (already in secrets.yaml, also used by
+  # open-webui and the MCP tooling) and render it as the env var the hermes
+  # `zai` provider reads.
+  sops.secrets."mcp_tokens/glm" = { };
+  sops.templates."hermes.env".content = ''
+    GLM_API_KEY=${config.sops.placeholder."mcp_tokens/glm"}
+  '';
+
+  services.hermes-agent = {
+    enable = true;
+
+    # Native, hardened systemd service (NoNewPrivileges, ProtectSystem=strict,
+    # PrivateTmp). The agent cannot self-install packages and only sees tools on
+    # the Nix-provided PATH. To allow runtime package installs in an isolated
+    # Ubuntu container instead, set `container.enable = true` (sandboxed, but
+    # mutable). Native mode is the more locked-down option for a first deploy.
+
+    settings = {
+      # z.ai / GLM. The explicit provider form is required here: a configured
+      # `model.base_url` is only honored when `model.provider` matches the
+      # resolved provider, so the slug form ("zai/glm-5.1") would silently
+      # ignore base_url and fall back to the general endpoint. We pin the
+      # Coding Plan endpoint, which is what the GLM key is scoped to.
+      model = {
+        provider = "zai";
+        default = "glm-5.1";
+        base_url = "https://api.z.ai/api/coding/paas/v4";
+      };
+
+      # Full tool access (web search, terminal, file editing, memory,
+      # delegation, etc.). NOTE: "all" includes the terminal toolset, so the
+      # agent can run shell commands as the `hermes` user on the host (in native
+      # mode, constrained only by the systemd hardening above). Switch to
+      # `container.enable = true` if you want shell execution sandboxed.
+      toolsets = [ "all" ];
+
+      # Max agent turns (one LLM call + its tool executions) per task before the
+      # agent stops. `agent.max_turns` is the authoritative key (a top-level
+      # `max_turns` is migrated into it at load time).
+      agent.max_turns = 100;
+
+      # Per-command timeout in seconds for the terminal toolset (kills any
+      # single shell command that runs longer than this).
+      terminal = {
+        backend = "local";
+        timeout = 180;
+      };
+    };
+
+    environmentFiles = [ config.sops.templates."hermes.env".path ];
+
+    # Put the `hermes` CLI on the system PATH and share state with the gateway.
+    addToSystemPackages = true;
+  };
+}


### PR DESCRIPTION
## Summary

Adds the [NousResearch hermes-agent](https://github.com/NousResearch/hermes-agent) to the homelab host as a **hardened native systemd service**, using **z.ai GLM-5.1** (Coding Plan endpoint) with **full tool access**.

### Changes
- `flake.nix` — add `hermes-agent` input (nixpkgs follows ours)
- `modules/hosts/homelab/_apps/hermes.nix` — new module wrapping `hermes-agent.nixosModules.default`
- `modules/hosts/homelab/_apps/default.nix` — register the import

### Configuration
- **Model**: z.ai GLM-5.1 via the explicit provider form, pinned to the Coding Plan endpoint:
  ```nix
  model = {
    provider = "zai";
    default = "glm-5.1";
    base_url = "https://api.z.ai/api/coding/paas/v4";
  };
  ```
  The explicit `model.provider` is **required** for `base_url` to take effect — verified against upstream source, a configured `base_url` is only honored when `model.provider` matches the resolved provider. The slug form (`"zai/glm-5.1"`) would silently ignore `base_url` and fall back to the general endpoint.
- **Tools**: `toolsets = [ "all" ]` — web search, terminal, file editing, memory, delegation, etc.
- **Turns**: `agent.max_turns = 100` (the authoritative key; top-level `max_turns` is migrated to it at load time).
- **Deployment**: native hardened mode (`NoNewPrivileges`, `ProtectSystem=strict`, `PrivateTmp`). The agent cannot self-install packages.
- **Secret**: reuses the existing `mcp_tokens/glm` secret (already in `secrets.yaml`, also used by open-webui and the MCP tooling) via a sops template that renders `GLM_API_KEY`. **No `secrets.yaml` change required.**

### Security note (re: "don't let it loose")
`toolsets = [ "all" ]` **includes the terminal toolset**, so the agent can run shell commands as the `hermes` user directly on the host (`terminal.backend = "local"`), constrained only by the systemd hardening. `terminal.timeout = 180` caps any single shell command.

If you want shell execution sandboxed in an isolated, mutable Ubuntu container instead, flip to container mode in `hermes.nix`:
```nix
services.hermes-agent.container.enable = true;   # + container.extraVolumes = [ ] to keep host dirs out
```
(Container mode auto-enables Docker; the homelab already runs Docker.)

## How to test

```bash
nix flake check                       # passes locally
# after merge:
sudo nixos-rebuild switch --flake .#homelab
systemctl status hermes-agent
journalctl -u hermes-agent -f
hermes version
```

## Notes
- `nix flake check` passes; the homelab NixOS configuration evaluates cleanly.
- The upstream module blocks `hermes setup` / `hermes config set` in managed mode — config is declarative via `settings`.
- Validated against ~13 public community configs: native mode + `toolsets=["all"]` + sops + `addToSystemPackages` are the dominant conventions.