### PR TITLE
feat(hermes): Enable OpenAI-compatible API server for Open WebUI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
 - Use mcp-nixos when searching for nix packages or options
 - You can run `nix flake check` to check whether the flake evaluates and run its tests
 - Use `gh` cli to interact with GitHub from the command line. For example, `gh pr create` to create a pull request.
-- Never modify `secrets.yaml`. If a task needs sops secret changes, continue the implementation as if they were already applied, then end by telling the user what to change in sops and include a command to generate the secret value (e.g. `openssl rand -hex 32` for API keys, `pwgen -s 64 1` for passwords).
+- Never modify `secrets.yaml`. If a task needs sops secret changes, continue the implementation as if they were already applied, then end by telling the user what to change in sops and include a command to generate the secret value.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
 - Use mcp-nixos when searching for nix packages or options
 - You can run `nix flake check` to check whether the flake evaluates and run its tests
 - Use `gh` cli to interact with GitHub from the command line. For example, `gh pr create` to create a pull request.
-- Never modify `secrets.yaml`. If a task needs sops secret changes, continue the implementation as if they were already applied, then end by telling the user what to change in sops.
+- Never modify `secrets.yaml`. If a task needs sops secret changes, continue the implementation as if they were already applied, then end by telling the user what to change in sops and include a command to generate the secret value (e.g. `openssl rand -hex 32` for API keys, `pwgen -s 64 1` for passwords).

--- a/modules/hosts/homelab/_apps/hermes.nix
+++ b/modules/hosts/homelab/_apps/hermes.nix
@@ -12,8 +12,11 @@
   # open-webui and the MCP tooling) and render it as the env var the hermes
   # `zai` provider reads.
   sops.secrets."mcp_tokens/glm" = { };
+  sops.secrets."hermes/api_server_key" = { };
   sops.templates."hermes.env".content = ''
     GLM_API_KEY=${config.sops.placeholder."mcp_tokens/glm"}
+    API_SERVER_ENABLED=true
+    API_SERVER_KEY=${config.sops.placeholder."hermes/api_server_key"}
   '';
 
   services.hermes-agent = {

--- a/secrets.yaml
+++ b/secrets.yaml
@@ -65,10 +65,11 @@ attic:
     client_token: ENC[AES256_GCM,data:A/t1nMPyFFH5NT9U0d/gH2c9Oy9tNhev5wRJuPqzVDSmBhbKOcuyOC6P+W6wJBGDTy0ppgw+wLKMibGqKv9TNHcuKgqcfC94ek9yRC2gmJ//AGz78ppbH37Kzr5nJMJg1VzFqGUsOt3ewRJRfdyrzibEn4FaK5RFm4WM5imtiljGboafa6sab52avdTvGP55nI3E2ezyLHL9NCqXcfQd15Lloq3Sy++Cp25c2C4wmL1+28oKT0Q4G/xerN4orFOHCw6P+XGGt2u3iOlLJali0f5yUCufQmJM/YyAPzUPhbRcRJQ0FQX4MfQ5fnA7GX7n4/Jll+s4fx/6olpnnzfRPeuoBb2fUDZRdgSq6Qe5cvH2nMIYCeR4OHDgqcRZvoH6HiCgD/P00qtlxRZZxJrSWWkN7ICooTeoKfDpEE35lzI/JzeIWrMYuYKZTNT4uk70+W5SB57ix4u9m6Gu104OiwD/2DXGBZ2kqr1umuRwW8NM7Vosft3Isq2kVAStvVVmG5DdseMF6i5BG8FxtZ/9ZcK+ScWXLIcOxpwUdqmOXOg86GD55zvUDnlA9fTMnpauctQhkVHqlNKzyHGMw2lTBSE2TvCl0ZEYLqH1xNPwGUHpoTpIWdtwjCK7lBZNNGvKwRQaQW3JWlMacpnkjUw6+qElaK6i6+EKn8Sk8K4dHfJZLCBPv5c2tVyKrpoe+cz/dhGe28o6r33HmNzXoXdViRbkmeNI0VxiOBFkYop+aZkX4y2A1KJKv1Nm5c5xdYRhQe5LnvblQUG1tIEAuC6e2ZjuaX7/TKULgYdpSsA2JunwOU/lbd7oiaMGBtr1xxyPWtelltmkrb41zHtMvgKg8WQMG/CLNXe80T2dqEydTF5rxTiiCva+0EAt84C8qVpmEPPPJj1uDHRUYVjp8q/p4n0cdr5Y+4LjDlNN7hsG5xIRCF7h9XRpx5mZLVTXBHfZpzEdrUNLmo+eVOPRh60oNXz3XZanrwA+dSAkgA3rPmx6W/ZUm22chB/hZTZnjEq1MqzJVUbMbAzktM1A3ar4KyP/rwrqg7Oem3CKOh5QR8x17M6fY6ofKtna6TpNKHVXhSJykqxVkbEOB2yi8DxXmRMn4Eu7w2COXvFcXsVDWUJ5LeAo4+gNbOSNdvVVmeA0jASEu9hZd0KuZHfMOAn7YlHYvxsIuFe79OVSV4BoynNp/JvOniM/IEcgeZo0gRRo,iv:qUKLrziG7TwNeRfPSGGsC3JilsfZ/2YHweq0Rl/3tp0=,tag:71fBJN06tvNfMjG/PORvTw==,type:str]
 grafana:
     secret_key: ENC[AES256_GCM,data:Qi9tlsp7oAeJ5w6C4vT9MC12YG6fw1GDl2zpXotSoqodhjuV3rzHLxLIGJKBnV7fq+jB/5AVZowTsmjbNJGv3w==,iv:Cm5ciAx+NnR0VaUWkohxdNanrSdgpDQBNx9s26riEyc=,tag:reZpqMRRiDmei+CrB+3N5w==,type:str]
+hermes:
+    api_server_key: ENC[AES256_GCM,data:tWgMxBJl+RErQWCBM+qA51voBIBXD9k5cNhby8B0QMMsYHP7VbiLTmUYAMp4XAFTWEkB0dp2AbTIuJKpELO9hg==,iv:NnQCH3Ic/BTFKOhYotQrWPslFVR9U2BgoqBbGJwSOwI=,tag:iODcjWuc4/XVW1L5Kp0YMA==,type:str]
 sops:
     age:
-        - recipient: age1tuff9rc0jgz0ssw6djgwygcncchgz3dq0m2uhj5dpgpt7f9uuvzqf60vj6
-          enc: |
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrZEJYZG5CdUdCdERTMXRl
             c2lGbGVoQTNDTk91RmVmSERnRC93VmQreENNCk5HQ0ppNHExRnFuaElLQWNQWGxo
@@ -76,8 +77,8 @@ sops:
             Q3Yyc2ExM0hJOGd1VFRBczdFQlJKQkEKSA8kkg0EkqkgM0aYKfvJHDhwLiDMfcEM
             M7n4gJLOQsPnV/zgUibSagYJTgCcixg0J9UhlBrk0Ta2vkproqQqCQ==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age1ddzcc6q035lcwmaudfsn3edyym4rngzcu5gr4lsneqt60spcrgpqxuru6f
-          enc: |
+          recipient: age1tuff9rc0jgz0ssw6djgwygcncchgz3dq0m2uhj5dpgpt7f9uuvzqf60vj6
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBLajBIWGRlN1pFT0Nqankr
             eXFnZHlrNjNYbmNzaTB0eXQ4NG9OSVFGUFUwCjRrNXE3ZVNvOEZBeE4yU29RREtk
@@ -85,8 +86,8 @@ sops:
             QUVqY3VEcFFMRWRvVC9TTmluTGZWb1UKYWBKhoo7VXsNk5L70z5i4u8M9UTW2RE6
             YP2uEL5NuLnY5691C3iuL3sioP6psxxCNYYsOKBIr2oS9vdobkQWWA==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age1hg84p3jc5lvxm8j2qypec6kxr94599tvvfesjkm2rrsnhf0xhcpq3rxcdw
-          enc: |
+          recipient: age1ddzcc6q035lcwmaudfsn3edyym4rngzcu5gr4lsneqt60spcrgpqxuru6f
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBYVUlqVHVHcE5lOUxMNmd2
             SEVuMkhZeG5jUVk2VU56SU5tVlZFZ1NMV1RNCmRuY1JvWkJleFEzL3NLZTBYMmRm
@@ -94,7 +95,8 @@ sops:
             N2gycHU4R216cHBxQkxMczVkNVpHUmcK50x5Ju/Qw1cB0hIvuUztS/vpiWUPxtWh
             jfnXgMaNSoogc4G/5YuTQrUstOtYxCKWPO+GLwHgUQyXD3E4b6FHdQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-06-01T18:04:57Z"
-    mac: ENC[AES256_GCM,data:4lOzcejy3laQUSgjyc7jebpgnoqP6/FiQRQut96r1FYf/bN/UkbPVM8h7udAMuZffmQI8ew09jMRCVjLca6OMoUI5kRsAExJVK402JKk3tSI68zLoche1k81bZZK3X8oR0dzSmJnRnOnGTkqdq4ZCrC8N1DAmsoo6mt4E2dFJB8=,iv:Wri3CTko9QS9ojxGquxAx1EJHOoFWDcdSv43/mO4S4s=,tag:PiajqXYQoqmi+SXSppRUFQ==,type:str]
+          recipient: age1hg84p3jc5lvxm8j2qypec6kxr94599tvvfesjkm2rrsnhf0xhcpq3rxcdw
+    lastmodified: "2026-06-03T10:59:45Z"
+    mac: ENC[AES256_GCM,data:4BvcIbcZPCqPd+QRLMZ4PiqjASpoqg7E0M5dOBPbBSndhmo7dWsYn+IXpMD5VTC3/0nweWvv9QzIn/5hLFofcaYLrDaixNH2MKIFRyXv1cqjNd2zv1rI5s6WfjxEeOWUmzQtzNP8l9Z+QF0NJyOKWSFECLdivxfTxeJjb5ZONZg=,iv:SDkXzGyQRU78KEnYUJuaiR2xVvegkJV4l3vlVMGVfvI=,tag:9CGTNiePT7klsDBabTtflg==,type:str]
     unencrypted_suffix: _unencrypted
-    version: 3.12.1
+    version: 3.13.1


### PR DESCRIPTION
## Summary

Enable hermes-agent's built-in OpenAI-compatible API server so Open WebUI (and other OpenAI-compatible clients) can connect to it as a backend model provider.

- Adds `API_SERVER_ENABLED=true` to the `hermes.env` sops template
- Adds `API_SERVER_KEY` referencing a new `hermes/api_server_key` sops secret

The API server listens on `127.0.0.1:8642` by default and exposes:
- `POST /v1/chat/completions` — OpenAI Chat Completions
- `POST /v1/responses` — OpenAI Responses API (stateful)
- `GET /v1/models` — lists `hermes-agent` as available model
- `GET /health` — health check

### Open WebUI config

| Setting | Value |
|---------|-------|
| URL | `http://localhost:8642/v1` |
| API Key | value of `hermes/api_server_key` secret |

## ⚠️ Before deploying

Add the `hermes/api_server_key` secret to `secrets.yaml` (any random string — it's the bearer token Open WebUI uses to authenticate). Per policy, this PR does not modify `secrets.yaml`.