### PR TITLE
fix(ci): resolve agent name casing mismatch in opencode-review workflow

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -99,6 +99,13 @@ jobs:
       - name: Configure agent prompts
         run: |
           OMO_JSON=~/.config/opencode/oh-my-openagent.json
+
+          # Fix agent key casing: install generates lowercase "sisyphus" but
+          # the agent registry requires capitalized "Sisyphus"
+          jq 'if .agents.sisyphus then .agents.Sisyphus = .agents.sisyphus | del(.agents.sisyphus) else . end' "$OMO_JSON" > /tmp/omo.json && mv /tmp/omo.json "$OMO_JSON"
+          jq 'if .agents["sisyphus-junior"] then .agents["Sisyphus-Junior"] = .agents["sisyphus-junior"] | del(.agents["sisyphus-junior"]) else . end' "$OMO_JSON" > /tmp/omo.json && mv /tmp/omo.json "$OMO_JSON"
+          jq '.default_run_agent = "Sisyphus"' "$OMO_JSON" > /tmp/omo.json && mv /tmp/omo.json "$OMO_JSON"
+
           PROMPT_APPEND=$(cat << 'PROMPT_EOF'
           <ultrawork-mode>
           [CODE RED] Maximum precision required. Ultrathink before acting.
@@ -375,7 +382,7 @@ jobs:
           PROMPT="${PROMPT//BRANCH_PLACEHOLDER/$DEFAULT_BRANCH}"
           PROMPT="${PROMPT//COMMENT_PLACEHOLDER/$USER_COMMENT}"
 
-          bunx oh-my-opencode run "$PROMPT"
+          bunx oh-my-opencode run --agent Sisyphus "$PROMPT"
 
       # Update reaction and remove label
       - name: Update reaction and remove label

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -94,17 +94,11 @@ jobs:
           opencode --version
 
       - name: Install oh-my-openagent plugin
-        run: bunx oh-my-opencode install --no-tui --claude=no --gemini=no --copilot=no --openai=no --opencode-go=no --opencode-zen=no --zai-coding-plan=yes --kimi-for-coding=no --vercel-ai-gateway=no --skip-auth
+        run: bunx oh-my-openagent@4.6.0 install --no-tui --claude=no --gemini=no --copilot=no --openai=no --opencode-go=no --opencode-zen=no --zai-coding-plan=yes --kimi-for-coding=no --vercel-ai-gateway=no --skip-auth
 
       - name: Configure agent prompts
         run: |
           OMO_JSON=~/.config/opencode/oh-my-openagent.json
-
-          # Fix agent key casing: install generates lowercase "sisyphus" but
-          # the agent registry requires capitalized "Sisyphus"
-          jq 'if .agents.sisyphus then .agents.Sisyphus = .agents.sisyphus | del(.agents.sisyphus) else . end' "$OMO_JSON" > /tmp/omo.json && mv /tmp/omo.json "$OMO_JSON"
-          jq 'if .agents["sisyphus-junior"] then .agents["Sisyphus-Junior"] = .agents["sisyphus-junior"] | del(.agents["sisyphus-junior"]) else . end' "$OMO_JSON" > /tmp/omo.json && mv /tmp/omo.json "$OMO_JSON"
-          jq '.default_run_agent = "Sisyphus"' "$OMO_JSON" > /tmp/omo.json && mv /tmp/omo.json "$OMO_JSON"
 
           PROMPT_APPEND=$(cat << 'PROMPT_EOF'
           <ultrawork-mode>
@@ -203,9 +197,9 @@ jobs:
           - user.email: omo-agent@users.noreply.github.com
           PROMPT_EOF
           )
-          jq --arg append "$PROMPT_APPEND" '.agents.Sisyphus.prompt_append = $append' "$OMO_JSON" > /tmp/omo.json && mv /tmp/omo.json "$OMO_JSON"
+          jq --arg append "$PROMPT_APPEND" '.agents.sisyphus.prompt_append = $append' "$OMO_JSON" > /tmp/omo.json && mv /tmp/omo.json "$OMO_JSON"
 
-          jq '.categories["unspecified-low"] = { "model": "zai-coding-plan/glm-5.1" }' "$OMO_JSON" > /tmp/omo.json && mv /tmp/omo.json "$OMO_JSON"
+          jq '(.agents[].model) |= sub("zai-coding-plan/glm-5$"; "zai-coding-plan/glm-5.1") | (.categories[].model) |= sub("zai-coding-plan/glm-5$"; "zai-coding-plan/glm-5.1")' "$OMO_JSON" > /tmp/omo.json && mv /tmp/omo.json "$OMO_JSON"
 
           OPENCODE_JSON=~/.config/opencode/opencode.json
           jq '.model = "zai-coding-plan/glm-5.1"' "$OPENCODE_JSON" > /tmp/oc.json && mv /tmp/oc.json "$OPENCODE_JSON"
@@ -382,7 +376,7 @@ jobs:
           PROMPT="${PROMPT//BRANCH_PLACEHOLDER/$DEFAULT_BRANCH}"
           PROMPT="${PROMPT//COMMENT_PLACEHOLDER/$USER_COMMENT}"
 
-          bunx oh-my-opencode run --agent Sisyphus "$PROMPT"
+          bunx oh-my-openagent@4.6.0 run "$PROMPT"
 
       # Update reaction and remove label
       - name: Update reaction and remove label


### PR DESCRIPTION
## Summary

The CI `omo-agent` was failing with `Agent not found: "sisyphus"` because `oh-my-openagent` 4.7.x introduced a regression that lowercases agent names via `AGENT_NAME_MAP` before passing them to the OpenCode server, which expects the original names.

### Fix

- Pin `oh-my-openagent@4.6.0` for both `install` and `run` commands
- Override `glm-5` → `glm-5.1` in config via jq (install writes the wrong model name)

### Why not 4.7.x?

In 4.7.x, `AGENT_NAME_MAP` normalizes all agent names to lowercase (e.g. `Sisyphus` → `sisyphus`) for config key purposes, but then passes the lowercase name to the OpenCode session API, which doesn't recognize it. This is an upstream bug.