### PR TITLE
fix: use integer port for mautrix-telegram appservice

### DIFF
--- a/modules/hosts/homelab/_apps/tuwunel.nix
+++ b/modules/hosts/homelab/_apps/tuwunel.nix
@@ -163,7 +163,7 @@ in
         as_token = "$MAUTRIX_TELEGRAM_APPSERVICE_AS_TOKEN";
         hs_token = "$MAUTRIX_TELEGRAM_APPSERVICE_HS_TOKEN";
         address = "http://127.0.0.1:29317";
-        port = "29317";
+        port = 29317;
         bot_username = "telegrambot";
         bot_displayname = "Telegram bridge bot";
         bot_avatar = "mxc://maunium.net/tJCRmUyJDsgRNgqhOgoiHWbX";


### PR DESCRIPTION
## Summary

Fixes the Telegram bridge being unresponsive by correcting the `port` type in `modules/hosts/homelab/_apps/tuwunel.nix`.

**The bug:** `port = "29317"` (Nix string) → JSON `"port": "29317"` (string) → Go `uint16` unmarshal fails → bridge exits with code 10 → crash loop.

**The fix:** `port = 29317` (Nix integer) → JSON `"port": 29317` (number) → Go `uint16` unmarshal succeeds.

## Changes

- `modules/hosts/homelab/_apps/tuwunel.nix`: Changed `port = "29317"` to `port = 29317` (line 166)

## Validation

- `nix flake check` passes ✅
- Consistent with all other bridges (instagram, messenger, signal) which use the module default integer port
- Consistent with the homeserver port on line 9 (`port = 6167` — integer)

Closes #72