### PR TITLE
feat(blog): serve CSP via nginx header with per-request nonce

### DIFF
--- a/modules/blog.nix
+++ b/modules/blog.nix
@@ -16,6 +16,18 @@
         locations."= /404.html".extraConfig = "internal;";
         extraConfig = ''
           error_page 404 /404.html;
+
+          # CSP is served as a response header (not the Zola <meta> tag) so that
+          # Cloudflare's JavaScript Detections can parse the per-request nonce and
+          # stamp it onto the inline script it injects at the edge. The injected
+          # scripts embed a per-request Ray ID + timestamp, so their hash changes
+          # on every load and cannot be pinned -- a nonce is the only workable
+          # option. Cloudflare stamps this same nonce onto every script it injects
+          # (JSD + Web Analytics beacon), so no hash is needed. $request_id is
+          # nginx's built-in per-request token (16 bytes of entropy).
+          # NOTE: requires the blog's <meta> CSP to be disabled, otherwise it
+          # co-enforces without a nonce and re-blocks the injected scripts.
+          add_header Content-Security-Policy "default-src 'self'; base-uri 'self'; connect-src 'self' cloudflareinsights.com; form-action 'self'; img-src 'self' data:; script-src 'self' static.cloudflareinsights.com 'nonce-$request_id'" always;
         '';
       };
     };


### PR DESCRIPTION
## Summary

Production was emitting CSP violations for the inline scripts Cloudflare injects at the edge (JavaScript Detections + Web Analytics). Those scripts embed a per-request Ray ID and timestamp, so their `sha256`/`sha512` hash changes on every load and can never be pinned.

This moves the CSP from the blog's static `<meta>` tag to an **nginx response header** carrying a **per-request nonce** (`$request_id`). Cloudflare parses the CSP response header and stamps the same nonce onto every script it injects, so they pass CSP without weakening it with `'unsafe-inline'`.

Changes in `modules/blog.nix`:
- Add `Content-Security-Policy` response header on the `ankarhem.dev` vhost (`always`, so it also covers the 404 page).
- Use nginx's built-in `$request_id` as the nonce (16 bytes of per-request entropy).
- Dropped the old `sha512` beacon hash — redundant now that Cloudflare nonces the beacon too, and brittle.

### How to test

1. Merge this **together with** the coupled change in `ankarhem/site` that disables the `<meta>` CSP.
2. Deploy, then load https://ankarhem.dev and confirm:
   - Response header `Content-Security-Policy` contains `script-src ... 'nonce-<value>'`.
   - The injected `<script>...__CF$cv$params...>` now carries `nonce="<same value>"`.
   - No CSP `script-src-elem` violations in the console.

> [!IMPORTANT]
> Depends on `ankarhem/site` disabling its `<meta>` CSP. If the meta tag is still present, it co-enforces without a nonce and re-blocks the injected scripts. Verify Cloudflare actually stamps the nonce for this proxied origin — if it does not, fall back to disabling JavaScript Detections in the Cloudflare dashboard.

## Related Issues

<!-- none -->